### PR TITLE
Remove unnecessary mut reference.

### DIFF
--- a/ohttp/src/lib.rs
+++ b/ohttp/src/lib.rs
@@ -239,7 +239,7 @@ impl KeyConfig {
         })
     }
 
-    fn select(&mut self, sym: SymmetricSuite) -> Res<HpkeConfig> {
+    fn select(&self, sym: SymmetricSuite) -> Res<HpkeConfig> {
         if self.symmetric.contains(&sym) {
             let config = HpkeConfig::new(self.kem, sym.kdf(), sym.aead());
             Ok(config)


### PR DESCRIPTION
KeyConfig::select() only creates a new HpkeConfig for matching
suites; it doesn't need to modify any internal state.