### PR TITLE
Use rust-hpke by default

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -49,12 +49,13 @@ jobs:
         name: Build
         with:
           command: build
-          args: --tests
+          args: --tests --no-default-features --features nss
 
       - uses: actions-rs/cargo@v1
         name: Run Tests
         with:
           command: test
+          args: --no-default-features --features nss
         env:
           LD_LIBRARY_PATH: ${{ github.workspace }}/dist/Debug/lib
 
@@ -70,7 +71,7 @@ jobs:
         if: ${{ success() || failure() }}
         with:
           command: clippy
-          args: --tests -- -D warnings
+          args: --tests --no-default-features --features nss -- -D warnings
 
   check_rust_hpke:
     name: rust-hpke Build
@@ -86,13 +87,12 @@ jobs:
         name: Build
         with:
           command: build
-          args: --tests --no-default-features --features rust-hpke
+          args: --tests
 
       - uses: actions-rs/cargo@v1
         name: Run Tests
         with:
           command: test
-          args: --no-default-features --features rust-hpke
 
       - uses: actions-rs/cargo@v1
         name: Check formatting
@@ -106,4 +106,4 @@ jobs:
         if: ${{ success() || failure() }}
         with:
           command: clippy
-          args: --tests --no-default-features --features rust-hpke -- -D warnings
+          args: --tests -- -D warnings

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ This is a rust implementation of [Oblivious
 HTTP](https://unicorn-wg.github.io/oblivious-http/draft-thomson-http-oblivious.html)
 and the supporting [Binary HTTP Messages](https://unicorn-wg.github.io/oblivious-http/draft-thomson-http-binary-message.html).
 
-This uses [NSS](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS)
-for cryptographic primitives.  The support for HPKE in NSS is currently
-experimental, so you will have to build NSS in order to use the `ohttp` crate.
 
 
 ## Using
@@ -32,9 +29,16 @@ cargo run --bin bhttp-convert < ./examples/response.txt | \
 ```
 
 
-## Getting and Building
+## Building against NSS
 
-The build setup is a little tricky, mostly because building NSS is a bit fiddly.
+The `ohttp` crate can use the
+[Network Security Service](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS)
+library from the Mozilla project instead of native rust crates for cryptographic primatives.
+
+
+The support for HPKE in NSS is currently experimental, so you will have to build
+NSS in order to use this feature. The setup is a little tricky, mostly because
+building NSS is itself a bit fiddly.
 
 First, you need a machine capable of [building
 NSS](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Building).
@@ -77,8 +81,8 @@ Then you should be able to build and run tests:
 
 ```sh
 cd $workspace
-cargo build
-cargo test
+cargo build --no-default-features --features nss
+cargo test --no-default-features --features nss
 ```
 
 

--- a/ohttp-client-cli/Cargo.toml
+++ b/ohttp-client-cli/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Martin Thomson <mt@lowentropy.net>"]
 edition = "2018"
 
 [features]
-default = ["nss"]
+default = ["rust-hpke"]
 nss = ["ohttp/nss"]
 rust-hpke = ["ohttp/rust-hpke"]
 [dependencies]

--- a/ohttp-client/Cargo.toml
+++ b/ohttp-client/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Martin Thomson <mt@lowentropy.net>"]
 edition = "2018"
 
 [features]
-default = ["nss"]
+default = ["rust-hpke"]
 nss = ["ohttp/nss"]
 rust-hpke = ["ohttp/rust-hpke"]
 

--- a/ohttp-server/Cargo.toml
+++ b/ohttp-server/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Martin Thomson <mt@lowentropy.net>"]
 edition = "2018"
 
 [features]
-default = ["nss"]
+default = ["rust-hpke"]
 nss = ["ohttp/nss"]
 rust-hpke = ["ohttp/rust-hpke"]
 

--- a/ohttp/Cargo.toml
+++ b/ohttp/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 build = "build.rs"
 
 [features]
-default = ["client", "server", "nss"]
+default = ["client", "server", "rust-hpke"]
 client = []
 server = []
 nss = []


### PR DESCRIPTION
Since nss is hard to build, use the rust hpke implementation by default.

- [x] Change default features
- [x] Update README
- [x] Update ci runs

Fixes #22 