### PR TITLE
guard against truncated ciphertext in Aead::open (nss)

### DIFF
--- a/ohttp/build.rs
+++ b/ohttp/build.rs
@@ -302,6 +302,7 @@ mod nss {
         );
         if let Some(minor) = v.next() {
             let minor = minor
+                .trim_end()
                 .parse::<u32>()
                 .expect("NSS minor version is not a number");
             assert!(

--- a/ohttp/src/lib.rs
+++ b/ohttp/src/lib.rs
@@ -536,6 +536,29 @@ mod test {
         assert_eq!(&response2[..], RESPONSE);
     }
 
+    #[test]
+    fn response_truncated() {
+        crate::init();
+
+        let server_config = KeyConfig::new(KEY_ID, KEM, Vec::from(SYMMETRIC)).unwrap();
+        let mut server = Server::new(server_config).unwrap();
+        let encoded_config = server.config().encode().unwrap();
+        trace!("Config: {}", hex::encode(&encoded_config));
+
+        let client = ClientRequest::new(&encoded_config).unwrap();
+        let (enc_request, client_response) = client.encapsulate(REQUEST).unwrap();
+        trace!("Request: {}", hex::encode(REQUEST));
+        trace!("Encapsulated Request: {}", hex::encode(&enc_request));
+
+        let (request, server_response) = server.decapsulate(&enc_request).unwrap();
+        assert_eq!(&request[..], REQUEST);
+
+        let enc_response = server_response.encapsulate(RESPONSE).unwrap();
+        trace!("Encapsulated Response: {}", hex::encode(&enc_response));
+
+        assert!(client_response.decapsulate(&enc_response[..16]).is_err());
+    }
+
     #[cfg(feature = "rust-hpke")]
     #[test]
     fn derive_key_pair() {

--- a/ohttp/src/nss/aead.rs
+++ b/ohttp/src/nss/aead.rs
@@ -149,15 +149,13 @@ impl Aead {
 
     pub fn open(&mut self, aad: &[u8], seq: SequenceNumber, ct: &[u8]) -> Res<Vec<u8>> {
         assert_eq!(self.mode, Mode::Decrypt);
-        if ct.len() < TAG_LEN {
-            return Err(Error::Truncated);
-        }
         let mut nonce = self.nonce_base;
         for (i, n) in nonce.iter_mut().rev().take(COUNTER_LEN).enumerate() {
             *n ^= u8::try_from((seq >> (8 * i)) & 0xff).unwrap();
         }
         let mut pt = vec![0; ct.len()]; // NSS needs more space than it uses for plaintext.
         let mut pt_len: c_int = 0;
+        let pt_expected = ct.len().checked_sub(TAG_LEN).ok_or(Error::Truncated)?;
         secstatus_to_res(unsafe {
             PK11_AEADOp(
                 *self.ctx,
@@ -169,15 +167,15 @@ impl Aead {
                 c_int_len(aad.len()),
                 pt.as_mut_ptr(),
                 &mut pt_len,
-                c_int_len(pt.len()),                           // signed :(
-                ct.as_ptr().add(ct.len() - TAG_LEN) as *mut _, // const cast :(
+                c_int_len(pt.len()),                    // signed :(
+                ct.as_ptr().add(pt_expected) as *mut _, // const cast :(
                 c_int_len(TAG_LEN),
                 ct.as_ptr(),
-                c_int_len(ct.len() - TAG_LEN),
+                c_int_len(pt_expected),
             )
         })?;
         let len = usize::try_from(pt_len).unwrap();
-        debug_assert_eq!(len, ct.len() - TAG_LEN);
+        debug_assert_eq!(len, pt_expected);
         pt.truncate(len);
         Ok(pt)
     }


### PR DESCRIPTION
This fixes #30 by checking the input ciphertext length.