### PR TITLE
Stop using env_logger

### DIFF
--- a/ohttp-client-cli/Cargo.toml
+++ b/ohttp-client-cli/Cargo.toml
@@ -10,6 +10,7 @@ nss = ["ohttp/nss"]
 rust-hpke = ["ohttp/rust-hpke"]
 
 [dependencies]
+env_logger = {version = "0.9", default-features = false}
 hex = "0.4"
 
 [dependencies.bhttp]

--- a/ohttp-client-cli/src/main.rs
+++ b/ohttp-client-cli/src/main.rs
@@ -6,6 +6,8 @@ use std::io::{self, BufRead, Write};
 
 fn main() {
     init();
+    let _ = env_logger::try_init();
+
     let mut input = io::BufReader::new(io::stdin());
     print!("Config: ");
     io::stdout().flush().unwrap();

--- a/ohttp-client/Cargo.toml
+++ b/ohttp-client/Cargo.toml
@@ -10,6 +10,7 @@ nss = ["ohttp/nss"]
 rust-hpke = ["ohttp/rust-hpke"]
 
 [dependencies]
+env_logger = {version = "0.9", default-features = false}
 hex = "0.4"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 rustls = { version = "0.19", features = ["dangerous_configuration"]}

--- a/ohttp-client/src/main.rs
+++ b/ohttp-client/src/main.rs
@@ -74,6 +74,7 @@ impl Args {
 async fn main() -> Res<()> {
     let args = Args::from_args();
     ::ohttp::init();
+    let _ = env_logger::try_init();
 
     let mut input: Box<dyn io::BufRead> = if let Some(infile) = &args.input {
         Box::new(io::BufReader::new(File::open(infile)?))

--- a/ohttp-server/Cargo.toml
+++ b/ohttp-server/Cargo.toml
@@ -10,6 +10,7 @@ nss = ["ohttp/nss"]
 rust-hpke = ["ohttp/rust-hpke"]
 
 [dependencies]
+env_logger = {version = "0.9", default-features = false}
 hex = "0.4"
 structopt = "0.3"
 tokio = { version = "1", features = ["full"] }

--- a/ohttp-server/src/main.rs
+++ b/ohttp-server/src/main.rs
@@ -100,6 +100,7 @@ fn with_ohttp(
 async fn main() -> Res<()> {
     let args = Args::from_args();
     ::ohttp::init();
+    let _ = env_logger::try_init();
 
     let config = KeyConfig::new(
         0,

--- a/ohttp/Cargo.toml
+++ b/ohttp/Cargo.toml
@@ -17,7 +17,6 @@ rust-hpke = ["hpke/x25519", "rand", "aead", "aes-gcm", "chacha20poly1305", "hkdf
 gecko = ["mozbuild"]
 
 [dependencies]
-env_logger = {version = "0.9", default-features = false}
 hex = "0.4"
 lazy_static = "1.4"
 log = {version = "0.4.0", default-features = false}
@@ -31,13 +30,16 @@ chacha20poly1305 = {version = "0.8", optional = true}
 byteorder = "1.3"
 
 [build-dependencies]
+mozbuild = {version = "0.1", optional = true}
 serde = "1.0"
 serde_derive = "1.0"
 toml = "0.5"
-mozbuild = {version = "0.1", optional = true}
 
 [build-dependencies.bindgen]
 version = "0.63"
 default-features = false
 optional = true
 features = ["runtime"]
+
+[dev-dependencies]
+env_logger = {version = "0.9", default-features = false}

--- a/ohttp/src/lib.rs
+++ b/ohttp/src/lib.rs
@@ -62,7 +62,6 @@ pub type KeyId = u8;
 pub fn init() {
     #[cfg(feature = "nss")]
     nss::init();
-    let _ = env_logger::try_init();
 }
 
 /// A tuple of KDF and AEAD identifiers.
@@ -479,9 +478,14 @@ mod test {
     ];
     const RESPONSE: &[u8] = &[0x01, 0x40, 0xc8];
 
+    fn init() {
+        crate::init();
+        let _ = env_logger::try_init();
+    }
+
     #[test]
     fn request_response() {
-        crate::init();
+        init();
 
         let server_config = KeyConfig::new(KEY_ID, KEM, Vec::from(SYMMETRIC)).unwrap();
         let mut server = Server::new(server_config).unwrap();
@@ -506,7 +510,7 @@ mod test {
 
     #[test]
     fn two_requests() {
-        crate::init();
+        init();
 
         let server_config = KeyConfig::new(KEY_ID, KEM, Vec::from(SYMMETRIC)).unwrap();
         let mut server = Server::new(server_config).unwrap();
@@ -535,7 +539,7 @@ mod test {
 
     #[test]
     fn response_truncated() {
-        crate::init();
+        init();
 
         let server_config = KeyConfig::new(KEY_ID, KEM, Vec::from(SYMMETRIC)).unwrap();
         let mut server = Server::new(server_config).unwrap();
@@ -570,7 +574,7 @@ mod test {
             0x01, 0x00, 0x03,
         ];
 
-        crate::init();
+        init();
 
         let config = KeyConfig::parse(EXPECTED_CONFIG).unwrap();
 


### PR DESCRIPTION
As noted in #32, we shouldn't be doing that.  Move it to a dev-dependency for tests.