### PR TITLE
loosen bhttp's url dependency

### DIFF
--- a/bhttp/Cargo.toml
+++ b/bhttp/Cargo.toml
@@ -17,7 +17,7 @@ read-http = []
 write-http = []
 
 [dependencies]
-url = "2.2.0"
+url = "2"
 
 [dev-dependencies]
 hex = "0.4"


### PR DESCRIPTION
In mozilla-central, url >= 2.2 causes test failures, so that crate is limited to 2.1 right now (see https://bugzilla.mozilla.org/show_bug.cgi?id=1734538). This changes bhttp's url dependency to not specify which minor version is required, so that any version with major version 2 can be used.