### PR TITLE
Check that there is enough input in read_vec

### DIFF
--- a/bhttp/src/parse.rs
+++ b/bhttp/src/parse.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "read-http")]
-use crate::{Error, Res};
+use crate::{Error, ReadSeek, Res};
+#[cfg(feature = "read-http")]
+use std::borrow::BorrowMut;
 
 pub const HTAB: u8 = 0x09;
 #[cfg(feature = "read-http")]
@@ -60,9 +62,13 @@ pub fn split_at(v: u8, mut line: Vec<u8>) -> Option<(Vec<u8>, Vec<u8>)> {
 }
 
 #[cfg(feature = "read-http")]
-pub fn read_line(r: &mut impl std::io::BufRead) -> Res<Vec<u8>> {
+pub fn read_line<T, R>(r: &mut T) -> Res<Vec<u8>>
+where
+    T: BorrowMut<R> + ?Sized,
+    R: ReadSeek + ?Sized,
+{
     let mut buf = Vec::new();
-    r.read_until(NL, &mut buf)?;
+    r.borrow_mut().read_until(NL, &mut buf)?;
     let tail = buf.pop();
     if tail != Some(NL) {
         return Err(Error::Truncated);

--- a/bhttp/tests/test.rs
+++ b/bhttp/tests/test.rs
@@ -208,3 +208,19 @@ fn bad_chunked() {
     let e = Message::read_http(&mut Cursor::new(REQUEST)).unwrap_err();
     assert!(matches!(e, Error::Truncated));
 }
+
+/// If a length field overruns the buffer, stop.
+#[test]
+fn oversized() {
+    const REQUEST: &[u8] = &[0x00, 0x01];
+    let e = Message::read_bhttp(&mut Cursor::new(REQUEST)).unwrap_err();
+    assert!(matches!(e, Error::Truncated));
+}
+
+/// If a length field overruns the buffer, stop before over-allocating.
+#[test]
+fn oversized_max() {
+    const REQUEST: &[u8] = &[0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff];
+    let e = Message::read_bhttp(&mut Cursor::new(REQUEST)).unwrap_err();
+    assert!(matches!(e, Error::Truncated));
+}

--- a/ohttp-client-cli/src/main.rs
+++ b/ohttp-client-cli/src/main.rs
@@ -29,7 +29,7 @@ fn main() {
         request_buf.push_str("\r\n");
     }
 
-    let req = Message::read_http(&mut io::BufReader::new(request_buf.as_bytes())).unwrap();
+    let req = Message::read_http(&mut io::Cursor::new(request_buf.as_bytes())).unwrap();
     let mut request = Vec::new();
     req.write_bhttp(Mode::KnownLength, &mut request).unwrap();
     let (enc_request, client_response) = client.encapsulate(&request).unwrap();
@@ -43,7 +43,7 @@ fn main() {
     let enc_response = hex::decode(rsp.trim()).unwrap();
     let dec_response = client_response.decapsulate(&enc_response).unwrap();
 
-    let response = Message::read_bhttp(&mut io::BufReader::new(&dec_response[..])).unwrap();
+    let response = Message::read_bhttp(&mut io::Cursor::new(&dec_response[..])).unwrap();
     println!("Response:");
     response.write_http(&mut io::stdout()).unwrap();
     println!("END");

--- a/ohttp-server/src/main.rs
+++ b/ohttp-server/src/main.rs
@@ -5,7 +5,7 @@ use ohttp::{
     hpke::{Aead, Kdf, Kem},
     KeyConfig, Server as OhttpServer, SymmetricSuite,
 };
-use std::io::BufReader;
+use std::io::Cursor;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -51,7 +51,7 @@ fn generate_reply(
 ) -> Res<Vec<u8>> {
     let mut ohttp = ohttp_ref.lock().unwrap();
     let (request, server_response) = ohttp.decapsulate(enc_request)?;
-    let bin_request = Message::read_bhttp(&mut BufReader::new(&request[..]))?;
+    let bin_request = Message::read_bhttp(&mut Cursor::new(&request[..]))?;
 
     let mut bin_response = Message::response(200);
     bin_response.write_content(b"Received:\r\n---8<---\r\n");


### PR DESCRIPTION
This required a bunch of API changes that were a little awkward to manage.  That is the bulk of the work here.

In the end, retaining the dynamic dispatch stuff that the CLI tools were using was too hard, so that isn't quite as elegant as it was.

Closes #35.