### PR TITLE
Add support for X25519Kyber768Draft00

### DIFF
--- a/ohttp/Cargo.toml
+++ b/ohttp/Cargo.toml
@@ -9,11 +9,13 @@ description = "Oblivious HTTP"
 repository = "https://github.com/martinthomson/ohttp"
 
 [features]
-default = ["client", "server", "rust-hpke"]
+default = ["client", "server", "rust-hpke-nopq"]
 client = []
 server = []
 nss = ["bindgen"]
-rust-hpke = ["hpke/x25519", "rand", "aead", "aes-gcm", "chacha20poly1305", "hkdf", "sha2", "hpke/xyber768d00"]
+rust-hpke-nopq = ["rust-hpke", "hpke"]
+rust-hpke-pq = ["rust-hpke", "hpke-pq"]
+rust-hpke = ["rand", "aead", "aes-gcm", "chacha20poly1305", "hkdf", "sha2"]
 gecko = ["mozbuild"]
 
 [dependencies]
@@ -28,13 +30,15 @@ log = {version = "0.4.0", default-features = false}
 rand = {version = "0.8", optional = true}
 sha2 = {version = "0.9", optional = true}
 thiserror = "1"
+hpke = {version = "0.10.0", optional = true, default-features = false, features = ["std", "x25519"]}
 
-[dependencies.hpke]
+[dependencies.hpke-pq]
+package="hpke"
 git="https://github.com/bwesterb/rust-hpke"
 branch="xyber768d00"
 optional=true
 default-features=false
-features=["std"]
+features=["std", "x25519", "xyber768d00"]
 
 [build-dependencies]
 mozbuild = {version = "0.1", optional = true}

--- a/ohttp/Cargo.toml
+++ b/ohttp/Cargo.toml
@@ -9,13 +9,12 @@ description = "Oblivious HTTP"
 repository = "https://github.com/martinthomson/ohttp"
 
 [features]
-default = ["client", "server", "rust-hpke-nopq"]
+default = ["client", "server", "rust-hpke"]
 client = []
 server = []
 nss = ["bindgen"]
-rust-hpke-nopq = ["rust-hpke", "hpke"]
-rust-hpke-pq = ["rust-hpke", "hpke-pq"]
-rust-hpke = ["rand", "aead", "aes-gcm", "chacha20poly1305", "hkdf", "sha2"]
+pq = ["hpke-pq"]
+rust-hpke = ["rand", "aead", "aes-gcm", "chacha20poly1305", "hkdf", "sha2", "hpke"]
 gecko = ["mozbuild"]
 
 [dependencies]

--- a/ohttp/Cargo.toml
+++ b/ohttp/Cargo.toml
@@ -35,7 +35,8 @@ hpke = {version = "0.10.0", optional = true, default-features = false, features 
 [dependencies.hpke-pq]
 package="hpke"
 git="https://github.com/bwesterb/rust-hpke"
-branch="xyber768d00"
+#branch="xyber768d00"
+rev="71efb5cb88d8798ccd1aea09a2c6bf003b0f7f72"
 optional=true
 default-features=false
 features=["std", "x25519", "xyber768d00"]

--- a/ohttp/Cargo.toml
+++ b/ohttp/Cargo.toml
@@ -13,7 +13,7 @@ default = ["client", "server", "rust-hpke"]
 client = []
 server = []
 nss = ["bindgen"]
-rust-hpke = ["hpke/x25519", "rand", "aead", "aes-gcm", "chacha20poly1305", "hkdf", "sha2"]
+rust-hpke = ["hpke/x25519", "rand", "aead", "aes-gcm", "chacha20poly1305", "hkdf", "sha2", "hpke/xyber768d00"]
 gecko = ["mozbuild"]
 
 [dependencies]
@@ -23,12 +23,18 @@ byteorder = "1.3"
 chacha20poly1305 = {version = "0.8", optional = true}
 hex = "0.4"
 hkdf = {version = "0.11", optional = true}
-hpke = {version = "0.10.0", optional = true, default-features = false, features = ["std"]}
 lazy_static = "1.4"
 log = {version = "0.4.0", default-features = false}
 rand = {version = "0.8", optional = true}
 sha2 = {version = "0.9", optional = true}
 thiserror = "1"
+
+[dependencies.hpke]
+git="https://github.com/bwesterb/rust-hpke"
+branch="xyber768d00"
+optional=true
+default-features=false
+features=["std"]
 
 [build-dependencies]
 mozbuild = {version = "0.1", optional = true}

--- a/ohttp/src/err.rs
+++ b/ohttp/src/err.rs
@@ -10,10 +10,10 @@ pub enum Error {
     Crypto(#[from] crate::nss::Error),
     #[error("an error was found in the format")]
     Format,
-    #[cfg(feature = "rust-hpke-nopq")]
+    #[cfg(all(feature = "rust-hpke", not(feature = "pq")))]
     #[error("a problem occurred with HPKE: {0}")]
     Hpke(#[from] ::hpke::HpkeError),
-    #[cfg(feature = "rust-hpke-pq")]
+    #[cfg(all(feature = "rust-hpke", feature = "pq"))]
     #[error("a problem occurred with HPKE: {0}")]
     Hpke(#[from] ::hpke_pq::HpkeError),
     #[error("an internal error occurred")]

--- a/ohttp/src/err.rs
+++ b/ohttp/src/err.rs
@@ -11,8 +11,11 @@ pub enum Error {
     #[error("an error was found in the format")]
     Format,
     #[error("a problem occurred with HPKE: {0}")]
-    #[cfg(feature = "rust-hpke")]
+    #[cfg(not(feature = "rust-hpke-pq"))]
     Hpke(#[from] ::hpke::HpkeError),
+    #[error("a problem occurred with HPKE: {0}")]
+    #[cfg(feature = "rust-hpke-pq")]
+    Hpke(#[from] ::hpke_pq::HpkeError),
     #[error("an internal error occurred")]
     Internal,
     #[error("the wrong type of key was provided for the selected KEM")]

--- a/ohttp/src/err.rs
+++ b/ohttp/src/err.rs
@@ -10,11 +10,11 @@ pub enum Error {
     Crypto(#[from] crate::nss::Error),
     #[error("an error was found in the format")]
     Format,
+    #[cfg(feature = "rust-hpke-nopq")]
     #[error("a problem occurred with HPKE: {0}")]
-    #[cfg(not(feature = "rust-hpke-pq"))]
     Hpke(#[from] ::hpke::HpkeError),
-    #[error("a problem occurred with HPKE: {0}")]
     #[cfg(feature = "rust-hpke-pq")]
+    #[error("a problem occurred with HPKE: {0}")]
     Hpke(#[from] ::hpke_pq::HpkeError),
     #[error("an internal error occurred")]
     Internal,

--- a/ohttp/src/hpke.rs
+++ b/ohttp/src/hpke.rs
@@ -33,7 +33,7 @@ convert_enum! {
 pub enum Kem {
     X25519Sha256 = 32,
 
-    #[cfg(feature = "rust-hpke-pq")]
+    #[cfg(feature = "pq")]
     X25519Kyber768Draft00 = 48,
 }
 }
@@ -44,7 +44,7 @@ impl Kem {
         match self {
             Kem::X25519Sha256 => 32,
 
-            #[cfg(feature = "rust-hpke-pq")]
+            #[cfg(feature = "pq")]
             Kem::X25519Kyber768Draft00 => 1120,
         }
     }
@@ -54,7 +54,7 @@ impl Kem {
         match self {
             Kem::X25519Sha256 => 32,
 
-            #[cfg(feature = "rust-hpke-pq")]
+            #[cfg(feature = "pq")]
             Kem::X25519Kyber768Draft00 => 1216,
         }
     }

--- a/ohttp/src/hpke.rs
+++ b/ohttp/src/hpke.rs
@@ -13,7 +13,9 @@ macro_rules! convert_enum {
 
             fn try_from(v: u16) -> Result<Self, Self::Error> {
                 match v {
-                    $(x if x == $name::$vname as u16 => Ok($name::$vname),)*
+                    $($(#[$vmeta])*
+                      x if x == $name::$vname as u16
+                      => Ok($name::$vname),)*
                     _ => Err(crate::Error::Unsupported),
                 }
             }
@@ -27,18 +29,12 @@ macro_rules! convert_enum {
     }
 }
 
-#[cfg(feature = "rust-hpke-pq")]
 convert_enum! {
 pub enum Kem {
     X25519Sha256 = 32,
-    X25519Kyber768Draft00 = 48,
-}
-}
 
-#[cfg(not(feature = "rust-hpke-pq"))]
-convert_enum! {
-pub enum Kem {
-    X25519Sha256 = 32,
+    #[cfg(feature = "rust-hpke-pq")]
+    X25519Kyber768Draft00 = 48,
 }
 }
 

--- a/ohttp/src/hpke.rs
+++ b/ohttp/src/hpke.rs
@@ -30,6 +30,7 @@ macro_rules! convert_enum {
 convert_enum! {
 pub enum Kem {
     X25519Sha256 = 32,
+    X25519Kyber768Draft00 = 48,
 }
 }
 
@@ -38,6 +39,7 @@ impl Kem {
     pub fn n_enc(self) -> usize {
         match self {
             Kem::X25519Sha256 => 32,
+            Kem::X25519Kyber768Draft00 => 1120,
         }
     }
 
@@ -45,6 +47,7 @@ impl Kem {
     pub fn n_pk(self) -> usize {
         match self {
             Kem::X25519Sha256 => 32,
+            Kem::X25519Kyber768Draft00 => 1216,
         }
     }
 }

--- a/ohttp/src/hpke.rs
+++ b/ohttp/src/hpke.rs
@@ -27,10 +27,18 @@ macro_rules! convert_enum {
     }
 }
 
+#[cfg(feature = "rust-hpke-pq")]
 convert_enum! {
 pub enum Kem {
     X25519Sha256 = 32,
     X25519Kyber768Draft00 = 48,
+}
+}
+
+#[cfg(not(feature = "rust-hpke-pq"))]
+convert_enum! {
+pub enum Kem {
+    X25519Sha256 = 32,
 }
 }
 
@@ -39,6 +47,8 @@ impl Kem {
     pub fn n_enc(self) -> usize {
         match self {
             Kem::X25519Sha256 => 32,
+
+            #[cfg(feature = "rust-hpke-pq")]
             Kem::X25519Kyber768Draft00 => 1120,
         }
     }
@@ -47,6 +57,8 @@ impl Kem {
     pub fn n_pk(self) -> usize {
         match self {
             Kem::X25519Sha256 => 32,
+
+            #[cfg(feature = "rust-hpke-pq")]
             Kem::X25519Kyber768Draft00 => 1216,
         }
     }

--- a/ohttp/src/lib.rs
+++ b/ohttp/src/lib.rs
@@ -14,9 +14,6 @@ mod rand;
 #[cfg(feature = "rust-hpke")]
 mod rh;
 
-#[cfg(all(featuer = "rust-hpke-pq", feature = "rust-hpke-nopq"))]
-compile_error!("Can't use rust-hpke-pq and rust-hpke-nopq at the same time");
-
 pub use err::Error;
 
 use crate::hpke::{Aead as AeadId, Kdf, Kem};

--- a/ohttp/src/lib.rs
+++ b/ohttp/src/lib.rs
@@ -14,6 +14,9 @@ mod rand;
 #[cfg(feature = "rust-hpke")]
 mod rh;
 
+#[cfg(all(featuer = "rust-hpke-pq", feature = "rust-hpke-nopq"))]
+compile_error!("Can't use rust-hpke-pq and rust-hpke-nopq at the same time");
+
 pub use err::Error;
 
 use crate::hpke::{Aead as AeadId, Kdf, Kem};

--- a/ohttp/src/rh/hpke.rs
+++ b/ohttp/src/rh/hpke.rs
@@ -221,7 +221,7 @@ impl HpkeS {
 
         macro_rules! dispatch_hpkes_new {
             {
-                ($c:expr, $pk:expr, $csprng:expr): [$({
+                ($c:expr, $pk:expr, $csprng:expr): [$( $(#[$meta:meta])* {
                     $kemid:path => $kem:path,
                     $kdfid:path => $kdf:path,
                     $aeadid:path => $aead:path,
@@ -230,6 +230,7 @@ impl HpkeS {
             } => {
                 match ($c, $pk) {
                     $(
+                        $(#[$meta])*
                         (
                             Config {
                                 kem: $kemid,
@@ -255,7 +256,6 @@ impl HpkeS {
             };
         }
 
-        #[cfg(feature = "rust-hpke-pq")]
         let (context, enc) = dispatch_hpkes_new! { (config, pk_r, &mut csprng): [
             {
                 Kem::X25519Sha256 => X25519HkdfSha256,
@@ -275,6 +275,8 @@ impl HpkeS {
                 SenderContextX25519HkdfSha256::HkdfSha256,
                 SenderContextX25519HkdfSha256HkdfSha256::ChaCha20Poly1305,
             },
+
+            #[cfg(feature = "rust-hpke-pq")]
             {
                 Kem::X25519Kyber768Draft00 => X25519Kyber768Draft00,
                 Kdf::HkdfSha256 => HkdfSha256,
@@ -283,28 +285,6 @@ impl HpkeS {
                 SenderContext::X25519Kyber768Draft00,
                 SenderContextX25519Kyber768Draft00::HkdfSha256,
                 SenderContextX25519Kyber768Draft00HkdfSha256::AesGcm128,
-            },
-        ]};
-
-        #[cfg(not(feature = "rust-hpke-pq"))]
-        let (context, enc) = dispatch_hpkes_new! { (config, pk_r, &mut csprng): [
-            {
-                Kem::X25519Sha256 => X25519HkdfSha256,
-                Kdf::HkdfSha256 => HkdfSha256,
-                Aead::Aes128Gcm => AesGcm128,
-                PublicKey::X25519,
-                SenderContext::X25519HkdfSha256,
-                SenderContextX25519HkdfSha256::HkdfSha256,
-                SenderContextX25519HkdfSha256HkdfSha256::AesGcm128,
-            },
-            {
-                Kem::X25519Sha256 => X25519HkdfSha256,
-                Kdf::HkdfSha256 => HkdfSha256,
-                Aead::ChaCha20Poly1305 => ChaCha20Poly1305,
-                PublicKey::X25519,
-                SenderContext::X25519HkdfSha256,
-                SenderContextX25519HkdfSha256::HkdfSha256,
-                SenderContextX25519HkdfSha256HkdfSha256::ChaCha20Poly1305,
             },
         ]};
 
@@ -460,7 +440,7 @@ impl HpkeR {
     ) -> Res<Self> {
         macro_rules! dispatch_hpker_new {
             {
-                ($c:ident, $sk:ident): [$({
+                ($c:ident, $sk:ident): [$( $(#[$meta:meta])* {
                     $kemid:path => $kem:path,
                     $kdfid:path => $kdf:path,
                     $aeadid:path => $aead:path,
@@ -469,6 +449,7 @@ impl HpkeR {
             } => {
                 match ($c, $sk) {
                     $(
+                        $(#[$meta])*
                         (
                             Config {
                                 kem: $kemid,
@@ -491,7 +472,6 @@ impl HpkeR {
                 }
             };
         }
-        #[cfg(feature = "rust-hpke-pq")]
         let context = dispatch_hpker_new! {(config, sk_r): [
             {
                 Kem::X25519Sha256 => X25519HkdfSha256,
@@ -511,6 +491,8 @@ impl HpkeR {
                 ReceiverContextX25519HkdfSha256::HkdfSha256,
                 ReceiverContextX25519HkdfSha256HkdfSha256::ChaCha20Poly1305,
             },
+
+            #[cfg(feature = "rust-hpke-pq")]
             {
                 Kem::X25519Kyber768Draft00 => X25519Kyber768Draft00,
                 Kdf::HkdfSha256 => HkdfSha256,
@@ -522,27 +504,6 @@ impl HpkeR {
             },
         ]};
 
-        #[cfg(not(feature = "rust-hpke-pq"))]
-        let context = dispatch_hpker_new! {(config, sk_r): [
-            {
-                Kem::X25519Sha256 => X25519HkdfSha256,
-                Kdf::HkdfSha256 => HkdfSha256,
-                Aead::Aes128Gcm => AesGcm128,
-                PrivateKey::X25519,
-                ReceiverContext::X25519HkdfSha256,
-                ReceiverContextX25519HkdfSha256::HkdfSha256,
-                ReceiverContextX25519HkdfSha256HkdfSha256::AesGcm128,
-            },
-            {
-                Kem::X25519Sha256 => X25519HkdfSha256,
-                Kdf::HkdfSha256 => HkdfSha256,
-                Aead::ChaCha20Poly1305 => ChaCha20Poly1305,
-                PrivateKey::X25519,
-                ReceiverContext::X25519HkdfSha256,
-                ReceiverContextX25519HkdfSha256::HkdfSha256,
-                ReceiverContextX25519HkdfSha256HkdfSha256::ChaCha20Poly1305,
-            },
-        ]};
         Ok(Self { context, config })
     }
 

--- a/ohttp/src/rh/hpke.rs
+++ b/ohttp/src/rh/hpke.rs
@@ -4,10 +4,10 @@ use crate::{
     Error, Res,
 };
 
-#[cfg(not(feature = "rust-hpke-pq"))]
+#[cfg(not(feature = "pq"))]
 use ::hpke as rust_hpke;
 
-#[cfg(feature = "rust-hpke-pq")]
+#[cfg(feature = "pq")]
 use ::hpke_pq as rust_hpke;
 
 use rust_hpke::{
@@ -17,7 +17,7 @@ use rust_hpke::{
     setup_receiver, setup_sender, Deserializable, OpModeR, OpModeS, Serializable,
 };
 
-#[cfg(feature = "rust-hpke-pq")]
+#[cfg(feature = "pq")]
 use rust_hpke::kem::X25519Kyber768Draft00;
 
 use ::rand::thread_rng;
@@ -69,7 +69,7 @@ impl Default for Config {
 pub enum PublicKey {
     X25519(<X25519HkdfSha256 as KemTrait>::PublicKey),
 
-    #[cfg(feature = "rust-hpke-pq")]
+    #[cfg(feature = "pq")]
     X25519Kyber768Draft00(<X25519Kyber768Draft00 as KemTrait>::PublicKey),
 }
 
@@ -79,7 +79,7 @@ impl PublicKey {
         Ok(match self {
             Self::X25519(k) => Vec::from(k.to_bytes().as_slice()),
 
-            #[cfg(feature = "rust-hpke-pq")]
+            #[cfg(feature = "pq")]
             Self::X25519Kyber768Draft00(k) => Vec::from(k.to_bytes().as_slice()),
         })
     }
@@ -99,7 +99,7 @@ impl std::fmt::Debug for PublicKey {
 pub enum PrivateKey {
     X25519(<X25519HkdfSha256 as KemTrait>::PrivateKey),
 
-    #[cfg(feature = "rust-hpke-pq")]
+    #[cfg(feature = "pq")]
     X25519Kyber768Draft00(<X25519Kyber768Draft00 as KemTrait>::PrivateKey),
 }
 
@@ -109,7 +109,7 @@ impl PrivateKey {
         Ok(match self {
             Self::X25519(k) => Vec::from(k.to_bytes().as_slice()),
 
-            #[cfg(feature = "rust-hpke-pq")]
+            #[cfg(feature = "pq")]
             Self::X25519Kyber768Draft00(k) => Vec::from(k.to_bytes().as_slice()),
         })
     }
@@ -132,7 +132,7 @@ enum SenderContextX25519HkdfSha256HkdfSha256 {
     ChaCha20Poly1305(Box<AeadCtxS<ChaCha20Poly1305, HkdfSha256, X25519HkdfSha256>>),
 }
 
-#[cfg(feature = "rust-hpke-pq")]
+#[cfg(feature = "pq")]
 enum SenderContextX25519Kyber768Draft00HkdfSha256 {
     AesGcm128(Box<AeadCtxS<AesGcm128, HkdfSha256, X25519Kyber768Draft00>>),
 }
@@ -141,7 +141,7 @@ enum SenderContextX25519HkdfSha256 {
     HkdfSha256(SenderContextX25519HkdfSha256HkdfSha256),
 }
 
-#[cfg(feature = "rust-hpke-pq")]
+#[cfg(feature = "pq")]
 enum SenderContextX25519Kyber768Draft00 {
     HkdfSha256(SenderContextX25519Kyber768Draft00HkdfSha256),
 }
@@ -149,7 +149,7 @@ enum SenderContextX25519Kyber768Draft00 {
 enum SenderContext {
     X25519HkdfSha256(SenderContextX25519HkdfSha256),
 
-    #[cfg(feature = "rust-hpke-pq")]
+    #[cfg(feature = "pq")]
     X25519Kyber768Draft00(SenderContextX25519Kyber768Draft00),
 }
 
@@ -169,7 +169,7 @@ impl SenderContext {
                 Vec::from(tag.to_bytes().as_slice())
             }
 
-            #[cfg(feature = "rust-hpke-pq")]
+            #[cfg(feature = "pq")]
             Self::X25519Kyber768Draft00(SenderContextX25519Kyber768Draft00::HkdfSha256(
                 SenderContextX25519Kyber768Draft00HkdfSha256::AesGcm128(context),
             )) => {
@@ -192,7 +192,7 @@ impl SenderContext {
                 context.export(info, out_buf)?;
             }
 
-            #[cfg(feature = "rust-hpke-pq")]
+            #[cfg(feature = "pq")]
             Self::X25519Kyber768Draft00(SenderContextX25519Kyber768Draft00::HkdfSha256(
                 SenderContextX25519Kyber768Draft00HkdfSha256::AesGcm128(context),
             )) => {
@@ -276,7 +276,7 @@ impl HpkeS {
                 SenderContextX25519HkdfSha256HkdfSha256::ChaCha20Poly1305,
             },
 
-            #[cfg(feature = "rust-hpke-pq")]
+            #[cfg(feature = "pq")]
             {
                 Kem::X25519Kyber768Draft00 => X25519Kyber768Draft00,
                 Kdf::HkdfSha256 => HkdfSha256,
@@ -333,7 +333,7 @@ enum ReceiverContextX25519HkdfSha256HkdfSha256 {
     ChaCha20Poly1305(Box<AeadCtxR<ChaCha20Poly1305, HkdfSha256, X25519HkdfSha256>>),
 }
 
-#[cfg(feature = "rust-hpke-pq")]
+#[cfg(feature = "pq")]
 enum ReceiverContextX25519Kyber768Draft00HkdfSha256 {
     AesGcm128(Box<AeadCtxR<AesGcm128, HkdfSha256, X25519Kyber768Draft00>>),
 }
@@ -342,7 +342,7 @@ enum ReceiverContextX25519HkdfSha256 {
     HkdfSha256(ReceiverContextX25519HkdfSha256HkdfSha256),
 }
 
-#[cfg(feature = "rust-hpke-pq")]
+#[cfg(feature = "pq")]
 enum ReceiverContextX25519Kyber768Draft00 {
     HkdfSha256(ReceiverContextX25519Kyber768Draft00HkdfSha256),
 }
@@ -350,7 +350,7 @@ enum ReceiverContextX25519Kyber768Draft00 {
 enum ReceiverContext {
     X25519HkdfSha256(ReceiverContextX25519HkdfSha256),
 
-    #[cfg(feature = "rust-hpke-pq")]
+    #[cfg(feature = "pq")]
     X25519Kyber768Draft00(ReceiverContextX25519Kyber768Draft00),
 }
 
@@ -382,7 +382,7 @@ impl ReceiverContext {
                 ct
             }
 
-            #[cfg(feature = "rust-hpke-pq")]
+            #[cfg(feature = "pq")]
             Self::X25519Kyber768Draft00(ReceiverContextX25519Kyber768Draft00::HkdfSha256(
                 ReceiverContextX25519Kyber768Draft00HkdfSha256::AesGcm128(context),
             )) => {
@@ -411,7 +411,7 @@ impl ReceiverContext {
                 context.export(info, out_buf)?;
             }
 
-            #[cfg(feature = "rust-hpke-pq")]
+            #[cfg(feature = "pq")]
             Self::X25519Kyber768Draft00(ReceiverContextX25519Kyber768Draft00::HkdfSha256(
                 ReceiverContextX25519Kyber768Draft00HkdfSha256::AesGcm128(context),
             )) => {
@@ -492,7 +492,7 @@ impl HpkeR {
                 ReceiverContextX25519HkdfSha256HkdfSha256::ChaCha20Poly1305,
             },
 
-            #[cfg(feature = "rust-hpke-pq")]
+            #[cfg(feature = "pq")]
             {
                 Kem::X25519Kyber768Draft00 => X25519Kyber768Draft00,
                 Kdf::HkdfSha256 => HkdfSha256,
@@ -517,7 +517,7 @@ impl HpkeR {
                 PublicKey::X25519(<X25519HkdfSha256 as KemTrait>::PublicKey::from_bytes(k)?)
             }
 
-            #[cfg(feature = "rust-hpke-pq")]
+            #[cfg(feature = "pq")]
             Kem::X25519Kyber768Draft00 => PublicKey::X25519Kyber768Draft00(
                 <X25519Kyber768Draft00 as KemTrait>::PublicKey::from_bytes(k)?,
             ),
@@ -557,7 +557,7 @@ pub fn generate_key_pair(kem: Kem) -> Res<(PrivateKey, PublicKey)> {
             (PrivateKey::X25519(sk), PublicKey::X25519(pk))
         }
 
-        #[cfg(feature = "rust-hpke-pq")]
+        #[cfg(feature = "pq")]
         Kem::X25519Kyber768Draft00 => {
             let (sk, pk) = X25519Kyber768Draft00::gen_keypair(&mut csprng);
             (
@@ -578,7 +578,7 @@ pub fn derive_key_pair(kem: Kem, ikm: &[u8]) -> Res<(PrivateKey, PublicKey)> {
             (PrivateKey::X25519(sk), PublicKey::X25519(pk))
         }
 
-        #[cfg(feature = "rust-hpke-pq")]
+        #[cfg(feature = "pq")]
         Kem::X25519Kyber768Draft00 => {
             let (sk, pk) = X25519Kyber768Draft00::derive_keypair(ikm);
             (
@@ -646,7 +646,7 @@ mod test {
         seal_open(Aead::ChaCha20Poly1305, Kem::X25519Sha256);
     }
 
-    #[cfg(feature = "rust-hpke-pq")]
+    #[cfg(feature = "pq")]
     #[test]
     fn seal_open_xyber768d00() {
         seal_open(Aead::Aes128Gcm, Kem::X25519Kyber768Draft00);


### PR DESCRIPTION
Maintainer of rust-hpke [prefers](https://github.com/rozbb/rust-hpke/pull/43) to wait for the final version of Kyber, before including support. I'd understand if you'd like to hold of as well because of that.

Cf. https://datatracker.ietf.org/doc/draft-westerbaan-cfrg-hpke-xyber768d00/
 
cc @chris-wood 