### PR TITLE
Provide constructors for ClientRequest from lists of configurations

### DIFF
--- a/ohttp-client-cli/src/main.rs
+++ b/ohttp-client-cli/src/main.rs
@@ -14,7 +14,7 @@ fn main() {
     let mut cfg = String::new();
     input.read_line(&mut cfg).unwrap();
     let config = hex::decode(cfg.trim()).unwrap();
-    let client = ClientRequest::new(&config).unwrap();
+    let client = ClientRequest::from_encoded_config(&config).unwrap();
 
     println!("Request (HTTP/1.1, terminate with \"END\"):");
     io::stdout().flush().unwrap();

--- a/ohttp-client/src/main.rs
+++ b/ohttp-client/src/main.rs
@@ -91,7 +91,7 @@ async fn main() -> Res<()> {
 
     let mut request_buf = Vec::new();
     request.write_bhttp(Mode::KnownLength, &mut request_buf)?;
-    let ohttp_request = ohttp::ClientRequest::new(&args.config)?;
+    let ohttp_request = ohttp::ClientRequest::from_encoded_config_list(&args.config)?;
     let (enc_request, ohttp_response) = ohttp_request.encapsulate(&request_buf)?;
     println!("Request: {}", hex::encode(&enc_request));
 

--- a/ohttp/src/lib.rs
+++ b/ohttp/src/lib.rs
@@ -298,7 +298,7 @@ pub struct ClientRequest {
 #[cfg(feature = "client")]
 impl ClientRequest {
     /// Construct a `ClientRequest` from a specific `KeyConfig` instance.
-    pub fn new_from_config(mut config: KeyConfig) -> Res<Self> {
+    pub fn from_config(mut config: KeyConfig) -> Res<Self> {
         // TODO(mt) choose the best config, not just the first.
         let selected = config.select(config.symmetric[0])?;
 

--- a/ohttp/src/lib.rs
+++ b/ohttp/src/lib.rs
@@ -323,7 +323,7 @@ impl ClientRequest {
     /// from the first supported configuration.
     /// See `KeyConfig::encode` for the structure details.
     #[allow(clippy::similar_names)] // for `sk_s` and `pk_s`
-    pub fn new_from_config_list(encoded_config_list: &[u8]) -> Res<Self> {
+    pub fn from_config_list(encoded_config_list: &[u8]) -> Res<Self> {
         let mut configs = KeyConfig::decode_list(encoded_config_list)?;
         let config = match configs.pop() {
             Some(c) => c,

--- a/ohttp/src/lib.rs
+++ b/ohttp/src/lib.rs
@@ -297,7 +297,7 @@ pub struct ClientRequest {
 
 #[cfg(feature = "client")]
 impl ClientRequest {
-    /// Construct a ClientRequest from a specific KeyConfig instance.
+    /// Construct a `ClientRequest` from a specific `KeyConfig` instance.
     pub fn new_from_config(mut config: KeyConfig) -> Res<Self> {
         // TODO(mt) choose the best config, not just the first.
         let selected = config.select(config.symmetric[0])?;
@@ -325,7 +325,10 @@ impl ClientRequest {
     #[allow(clippy::similar_names)] // for `sk_s` and `pk_s`
     pub fn new_from_config_list(encoded_config_list: &[u8]) -> Res<Self> {
         let mut configs = KeyConfig::decode_list(encoded_config_list)?;
-        let config = configs.pop().unwrap();
+        let config = match configs.pop() {
+            Some(c) => c,
+            None => return Err(Error::Unsupported),
+        };
         Self::new_from_config(config)
     }
 

--- a/ohttp/src/lib.rs
+++ b/ohttp/src/lib.rs
@@ -734,7 +734,7 @@ mod test {
     }
 
     #[test]
-    fn test_request_from_config_list() {
+    fn request_from_config_list() {
         init();
 
         let server_config = KeyConfig::new(KEY_ID, KEM, Vec::from(SYMMETRIC)).unwrap();


### PR DESCRIPTION
While we provided a way to construct KeyConfigs from list, we didn't plumb that up into ClientRequests. This plugs that gap.