### PR TITLE
Support using NSS in application-services

### DIFF
--- a/ohttp/Cargo.toml
+++ b/ohttp/Cargo.toml
@@ -15,7 +15,9 @@ server = []
 nss = ["bindgen"]
 pq = ["hpke-pq"]
 rust-hpke = ["rand", "aead", "aes-gcm", "chacha20poly1305", "hkdf", "sha2", "hpke"]
-gecko = ["mozbuild"]
+gecko = ["nss", "mozbuild"]
+app-svc = ["nss"]
+external-sqlite = []
 
 [dependencies]
 aead = {version = "0.4", optional = true, features = ["std"]}

--- a/ohttp/build.rs
+++ b/ohttp/build.rs
@@ -324,8 +324,8 @@ mod nss {
             nsslibdir.to_str().unwrap()
         );
         if is_debug() {
-            let use_static_softoken = false;
-            let use_static_nspr = false;
+            let use_static_softoken = true;
+            let use_static_nspr = true;
             static_link(&nsslibdir, use_static_softoken, use_static_nspr);
         } else {
             dynamic_link();

--- a/ohttp/src/nss/aead.rs
+++ b/ohttp/src/nss/aead.rs
@@ -44,6 +44,8 @@ unsafe fn destroy_aead_context(ctx: *mut PK11Context) {
 }
 scoped_ptr!(Context, PK11Context, destroy_aead_context);
 
+unsafe impl Send for Context {}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Mode {
     Encrypt,


### PR DESCRIPTION
Similar to the 'gecko' feature, I want to consider adding an 'app-svc' feature to use NSS for ohttp when built into application-services: https://github.com/mozilla/application-services/tree/main/components/as-ohttp-client . This is only used for iOS targets where we using static linking of NSS.

The existing ohttp build code for NSS ends up linking some of the NSS libraries statically, but calls dlopen under the covers to get softokn3.so and freebl.so. To do a full static link, instead I need to use pk11wrap_static/softokn_static/freebl_static. I made this an option for the app-svc build, but we could also change the default for NSS debug builds. My guess is that the static linking for NSS in debug for this ohttp crate was just to avoid mucking with LD_LIBRARY_PATH, in which case doing the full static link is probably a better path to the same result.

Down the road, I'd like to consider unifying the many build.rs scripts in gecko/app-svc to consolidate build system goo for gecko, etc. My thinking is to move into the application-services:nss_build_common which will become part of mozilla-unified. Then the logic around gecko builds, as well as around static nss builds could be maintained once. For now though, I'm just trying to getting the ohttp crate shipped on Firefox iOS.

If these changes are too specific to app-svc usage, I could try to make them just general parameters of the existing nss feature flag.