### PR TITLE
Parse key config rather than config list

### DIFF
--- a/ohttp-client/src/main.rs
+++ b/ohttp-client/src/main.rs
@@ -91,7 +91,7 @@ async fn main() -> Res<()> {
 
     let mut request_buf = Vec::new();
     request.write_bhttp(Mode::KnownLength, &mut request_buf)?;
-    let ohttp_request = ohttp::ClientRequest::from_encoded_config_list(&args.config)?;
+    let ohttp_request = ohttp::ClientRequest::from_encoded_config(&args.config)?;
     let (enc_request, ohttp_response) = ohttp_request.encapsulate(&request_buf)?;
     println!("Request: {}", hex::encode(&enc_request));
 


### PR DESCRIPTION
The ohttp-server prints an encoded config to stdout. Have the ohttp-client parse this instead of an encoded config list to make the ohttp-client and ohttp-server compatible.

Fix #52 