### PR TITLE
Fix Ergonomics

### DIFF
--- a/ohttp-server/src/main.rs
+++ b/ohttp-server/src/main.rs
@@ -51,7 +51,7 @@ fn generate_reply(
     enc_request: &[u8],
     mode: Mode,
 ) -> Res<Vec<u8>> {
-    let mut ohttp = ohttp_ref.lock().unwrap();
+    let ohttp = ohttp_ref.lock().unwrap();
     let (request, server_response) = ohttp.decapsulate(enc_request)?;
     let bin_request = Message::read_bhttp(&mut Cursor::new(&request[..]))?;
 

--- a/ohttp/src/config.rs
+++ b/ohttp/src/config.rs
@@ -48,6 +48,7 @@ impl SymmetricSuite {
 /// An important invariant of this structure is that it does not include
 /// any combination of KEM, KDF, and AEAD that is not supported.
 #[allow(clippy::module_name_repetitions)]
+#[derive(Debug, Clone)]
 pub struct KeyConfig {
     pub(crate) key_id: KeyId,
     pub(crate) kem: Kem,

--- a/ohttp/src/lib.rs
+++ b/ohttp/src/lib.rs
@@ -149,6 +149,7 @@ impl ClientRequest {
 /// It holds a single key pair and can generate a configuration.
 /// (A more complex server would have multiple key pairs. This is simple.)
 #[cfg(feature = "server")]
+#[derive(Debug, Clone)]
 pub struct Server {
     config: KeyConfig,
 }

--- a/ohttp/src/lib.rs
+++ b/ohttp/src/lib.rs
@@ -173,7 +173,7 @@ impl Server {
     /// # Panics
     /// Not as a consequence of this code, but Rust won't know that for sure.
     #[allow(clippy::similar_names)] // for kem_id and key_id
-    pub fn decapsulate(&mut self, enc_request: &[u8]) -> Res<(Vec<u8>, ServerResponse)> {
+    pub fn decapsulate(&self, enc_request: &[u8]) -> Res<(Vec<u8>, ServerResponse)> {
         if enc_request.len() < REQUEST_HEADER_LEN {
             return Err(Error::Truncated);
         }
@@ -201,7 +201,7 @@ impl Server {
         let mut hpke = HpkeR::new(
             cfg,
             &self.config.pk,
-            self.config.sk.as_mut().unwrap(),
+            self.config.sk.as_ref().unwrap(),
             &enc,
             &info,
         )?;
@@ -343,7 +343,7 @@ mod test {
         init();
 
         let server_config = KeyConfig::new(KEY_ID, KEM, Vec::from(SYMMETRIC)).unwrap();
-        let mut server = Server::new(server_config).unwrap();
+        let server = Server::new(server_config).unwrap();
         let encoded_config = server.config().encode().unwrap();
         trace!("Config: {}", hex::encode(&encoded_config));
 
@@ -368,7 +368,7 @@ mod test {
         init();
 
         let server_config = KeyConfig::new(KEY_ID, KEM, Vec::from(SYMMETRIC)).unwrap();
-        let mut server = Server::new(server_config).unwrap();
+        let server = Server::new(server_config).unwrap();
         let encoded_config = server.config().encode().unwrap();
 
         let client1 = ClientRequest::from_encoded_config(&encoded_config).unwrap();
@@ -408,7 +408,7 @@ mod test {
         init();
 
         let server_config = KeyConfig::new(KEY_ID, KEM, Vec::from(SYMMETRIC)).unwrap();
-        let mut server = Server::new(server_config).unwrap();
+        let server = Server::new(server_config).unwrap();
         let encoded_config = server.config().encode().unwrap();
 
         let client = ClientRequest::from_encoded_config(&encoded_config).unwrap();
@@ -439,7 +439,7 @@ mod test {
         init();
 
         let server_config = KeyConfig::new(KEY_ID, KEM, Vec::from(SYMMETRIC)).unwrap();
-        let mut server = Server::new(server_config).unwrap();
+        let server = Server::new(server_config).unwrap();
         let encoded_config = server.config().encode().unwrap();
 
         let client = ClientRequest::from_encoded_config(&encoded_config).unwrap();
@@ -498,7 +498,7 @@ mod test {
         init();
 
         let server_config = KeyConfig::new(KEY_ID, KEM, Vec::from(SYMMETRIC)).unwrap();
-        let mut server = Server::new(server_config).unwrap();
+        let server = Server::new(server_config).unwrap();
         let encoded_config = server.config().encode().unwrap();
 
         let mut header: [u8; 2] = [0; 2];

--- a/ohttp/src/nss/hpke.rs
+++ b/ohttp/src/nss/hpke.rs
@@ -170,7 +170,7 @@ impl HpkeR {
     pub fn new(
         config: Config,
         pk_r: &PublicKey,
-        sk_r: &mut PrivateKey,
+        sk_r: &PrivateKey,
         enc: &[u8],
         info: &[u8],
     ) -> Res<Self> {
@@ -304,9 +304,9 @@ mod test {
     fn make() {
         init();
         let cfg = Config::default();
-        let (mut sk_r, mut pk_r) = generate_key_pair(cfg.kem()).unwrap();
+        let (sk_r, mut pk_r) = generate_key_pair(cfg.kem()).unwrap();
         let hpke_s = HpkeS::new(cfg, &mut pk_r, INFO).unwrap();
-        let _hpke_r = HpkeR::new(cfg, &pk_r, &mut sk_r, &hpke_s.enc().unwrap(), INFO).unwrap();
+        let _hpke_r = HpkeR::new(cfg, &pk_r, &sk_r, &hpke_s.enc().unwrap(), INFO).unwrap();
     }
 
     #[allow(clippy::similar_names)] // for sk_x and pk_x
@@ -318,7 +318,7 @@ mod test {
             ..Config::default()
         };
         assert!(cfg.supported());
-        let (mut sk_r, mut pk_r) = generate_key_pair(cfg.kem()).unwrap();
+        let (sk_r, mut pk_r) = generate_key_pair(cfg.kem()).unwrap();
 
         // Send
         let mut hpke_s = HpkeS::new(cfg, &mut pk_r, INFO).unwrap();
@@ -326,7 +326,7 @@ mod test {
         let ct = hpke_s.seal(AAD, PT).unwrap();
 
         // Receive
-        let mut hpke_r = HpkeR::new(cfg, &pk_r, &mut sk_r, &enc, INFO).unwrap();
+        let mut hpke_r = HpkeR::new(cfg, &pk_r, &sk_r, &enc, INFO).unwrap();
         let pt = hpke_r.open(AAD, &ct).unwrap();
         assert_eq!(&pt[..], PT);
     }

--- a/ohttp/src/rh/hpke.rs
+++ b/ohttp/src/rh/hpke.rs
@@ -610,9 +610,9 @@ mod test {
     fn make() {
         init();
         let cfg = Config::default();
-        let (mut sk_r, mut pk_r) = generate_key_pair(cfg.kem()).unwrap();
+        let (sk_r, mut pk_r) = generate_key_pair(cfg.kem()).unwrap();
         let hpke_s = HpkeS::new(cfg, &mut pk_r, INFO).unwrap();
-        let _hpke_r = HpkeR::new(cfg, &pk_r, &mut sk_r, &hpke_s.enc().unwrap(), INFO).unwrap();
+        let _hpke_r = HpkeR::new(cfg, &pk_r, &sk_r, &hpke_s.enc().unwrap(), INFO).unwrap();
     }
 
     #[allow(clippy::similar_names)] // for sk_x and pk_x
@@ -625,7 +625,7 @@ mod test {
             ..Config::default()
         };
         assert!(cfg.supported());
-        let (mut sk_r, mut pk_r) = generate_key_pair(cfg.kem()).unwrap();
+        let (sk_r, mut pk_r) = generate_key_pair(cfg.kem()).unwrap();
 
         // Send
         let mut hpke_s = HpkeS::new(cfg, &mut pk_r, INFO).unwrap();
@@ -633,7 +633,7 @@ mod test {
         let ct = hpke_s.seal(AAD, PT).unwrap();
 
         // Receive
-        let mut hpke_r = HpkeR::new(cfg, &pk_r, &mut sk_r, &enc, INFO).unwrap();
+        let mut hpke_r = HpkeR::new(cfg, &pk_r, &sk_r, &enc, INFO).unwrap();
         let pt = hpke_r.open(AAD, &ct).unwrap();
         assert_eq!(&pt[..], PT);
     }

--- a/ohttp/src/rh/hpke.rs
+++ b/ohttp/src/rh/hpke.rs
@@ -66,6 +66,7 @@ impl Default for Config {
 }
 
 #[allow(clippy::large_enum_variant)]
+#[derive(Clone)]
 pub enum PublicKey {
     X25519(<X25519HkdfSha256 as KemTrait>::PublicKey),
 
@@ -96,6 +97,7 @@ impl std::fmt::Debug for PublicKey {
 }
 
 #[allow(clippy::large_enum_variant)]
+#[derive(Clone)]
 pub enum PrivateKey {
     X25519(<X25519HkdfSha256 as KemTrait>::PrivateKey),
 

--- a/ohttp/src/rh/hpke.rs
+++ b/ohttp/src/rh/hpke.rs
@@ -434,7 +434,7 @@ impl HpkeR {
     pub fn new(
         config: Config,
         _pk_r: &PublicKey,
-        sk_r: &mut PrivateKey,
+        sk_r: &PrivateKey,
         enc: &[u8],
         info: &[u8],
     ) -> Res<Self> {


### PR DESCRIPTION
- patch 1 allows Server::decapsulate to take `&self` instead of `&mut self` since `Server` is not mutated
- patch 2 derives debug, clone for ohttp::Server for ergonomics downstream

clippy passes w/o warnings