### PR TITLE
Construct `ClientRequest` from `&mut KeyConfig`

### DIFF
--- a/ohttp/src/lib.rs
+++ b/ohttp/src/lib.rs
@@ -92,7 +92,7 @@ pub struct ClientRequest {
 #[cfg(feature = "client")]
 impl ClientRequest {
     /// Construct a `ClientRequest` from a specific `KeyConfig` instance.
-    pub fn from_config(mut config: KeyConfig) -> Res<Self> {
+    pub fn from_config(config: &mut KeyConfig) -> Res<Self> {
         // TODO(mt) choose the best config, not just the first.
         let selected = config.select(config.symmetric[0])?;
 
@@ -108,8 +108,8 @@ impl ClientRequest {
     /// Reads an encoded configuration and constructs a single use client sender.
     /// See `KeyConfig::decode` for the structure details.
     pub fn from_encoded_config(encoded_config: &[u8]) -> Res<Self> {
-        let config = KeyConfig::decode(encoded_config)?;
-        Self::from_config(config)
+        let mut config = KeyConfig::decode(encoded_config)?;
+        Self::from_config(&mut config)
     }
 
     /// Reads an encoded list of configurations and constructs a single use client sender
@@ -117,11 +117,11 @@ impl ClientRequest {
     /// See `KeyConfig::decode_list` for the structure details.
     pub fn from_encoded_config_list(encoded_config_list: &[u8]) -> Res<Self> {
         let mut configs = KeyConfig::decode_list(encoded_config_list)?;
-        let config = match configs.pop() {
+        let mut config = match configs.pop() {
             Some(c) => c,
             None => return Err(Error::Unsupported),
         };
-        Self::from_config(config)
+        Self::from_config(&mut config)
     }
 
     /// Encapsulate a request.  This consumes this object.

--- a/ohttp/src/nss/mod.rs
+++ b/ohttp/src/nss/mod.rs
@@ -11,7 +11,7 @@ pub mod aead;
 pub mod hkdf;
 pub mod hpke;
 
-pub use self::p11::{random, PrivateKey, PublicKey, SymKey};
+pub use self::p11::{random, PrivateKey, PublicKey};
 use err::secstatus_to_res;
 pub use err::Error;
 use lazy_static::lazy_static;

--- a/ohttp/src/rh/aead.rs
+++ b/ohttp/src/rh/aead.rs
@@ -54,7 +54,7 @@ impl AeadEngine {
 /// A switch-hitting AEAD that uses a selected primitive.
 pub struct Aead {
     mode: Mode,
-    aead: AeadEngine,
+    engine: AeadEngine,
     nonce_base: [u8; NONCE_LEN],
     seq: SequenceNumber,
 }
@@ -80,7 +80,7 @@ impl Aead {
         };
         Ok(Self {
             mode,
-            aead,
+            engine: aead,
             nonce_base,
             seq: 0,
         })
@@ -105,14 +105,14 @@ impl Aead {
         // A copy for the nonce generator to write into.  But we don't use the value.
         let nonce = self.nonce(self.seq);
         self.seq += 1;
-        let ct = self.aead.encrypt(&nonce, Payload { msg: pt, aad })?;
+        let ct = self.engine.encrypt(&nonce, Payload { msg: pt, aad })?;
         Ok(ct)
     }
 
     pub fn open(&mut self, aad: &[u8], seq: SequenceNumber, ct: &[u8]) -> Res<Vec<u8>> {
         assert_eq!(self.mode, Mode::Decrypt);
         let nonce = self.nonce(seq);
-        let pt = self.aead.decrypt(&nonce, Payload { msg: ct, aad })?;
+        let pt = self.engine.decrypt(&nonce, Payload { msg: ct, aad })?;
         Ok(pt)
     }
 }


### PR DESCRIPTION
ClientRequests are single use so one making multiple requests needs to use the KeyConfig multiple times. Making each one from a reference rather than an owned `KeyConfig` allows this.

edit: The CI errors appear to be from the new clippy version and do not have to do with this change