### PR TITLE
Revert "Use let-else"

### DIFF
--- a/ohttp/src/lib.rs
+++ b/ohttp/src/lib.rs
@@ -117,8 +117,9 @@ impl ClientRequest {
     /// See `KeyConfig::decode_list` for the structure details.
     pub fn from_encoded_config_list(encoded_config_list: &[u8]) -> Res<Self> {
         let mut configs = KeyConfig::decode_list(encoded_config_list)?;
-        let Some(mut config) = configs.pop() else {
-            return Err(Error::Unsupported);
+        let mut config = match configs.pop() {
+            Some(c) => c,
+            None => return Err(Error::Unsupported),
         };
         Self::from_config(&mut config)
     }


### PR DESCRIPTION
This reverts commit a25a42d5f0d381ec4ec985ecd7b081912461eb78 in order to build on MSRV 1.63.0 and fix #57 

I confirmed that this builds as a dependency on rust 1.63.0 here https://github.com/DanGould/rust-payjoin/actions/runs/7464942355/job/20313029917