### PR TITLE
Fix clippy lint when feature `nss` is enabled

### DIFF
--- a/ohttp/build.rs
+++ b/ohttp/build.rs
@@ -37,7 +37,7 @@ mod nss {
         opaque: Vec<String>,
         /// enumerations that are turned into a module (without this, the enum is
         /// mapped using the default, which means that the individual values are
-        /// formed with an underscore as <enum_type>_<enum_value_name>).
+        /// formed with an underscore as `<enum_type>_<enum_value_name>`).
         #[serde(default)]
         enums: Vec<String>,
 


### PR DESCRIPTION
This was causing CI failures as in [1].

[1]: https://github.com/martinthomson/ohttp/actions/runs/9104919358/job/25029611078