### PR TITLE
Update hpke and hpke-pq to 0.11.0

### DIFF
--- a/ohttp/Cargo.toml
+++ b/ohttp/Cargo.toml
@@ -28,7 +28,7 @@ byteorder = "1.4"
 chacha20poly1305 = {version = "0.8", optional = true}
 hex = "0.4"
 hkdf = {version = "0.11", optional = true}
-hpke = {version = "0.10.0", optional = true, default-features = false, features = ["std", "x25519"]}
+hpke = {version = "0.11.0", optional = true, default-features = false, features = ["std", "x25519"]}
 lazy_static = "1.4"
 log = {version = "0.4", default-features = false}
 rand = {version = "0.8", optional = true}
@@ -42,10 +42,10 @@ thiserror = "1"
 
 [dependencies.hpke-pq]
 package = "hpke_pq"
-version = "0.10.1"
+version = "0.11.0"
 git = "https://github.com/bwesterb/rust-hpke"
 #branch = "xyber768d00"
-rev = "74eed1b8c11a3b3fecee083952a62cb34b63c3c7"
+rev = "4e7e359fb7f86d4fa42e1bc38fad7f5c6b224a07"
 optional = true
 default-features = false
 features = ["std", "x25519", "xyber768d00"]


### PR DESCRIPTION
This version of `hpke` moves `x25519-dalek` to a stable version, letting downstream users get the fix for https://rustsec.org/advisories/RUSTSEC-2024-0344.

The pinned version of `hpke-pq` [also fixes the CI](https://github.com/bwesterb/rust-hpke/pull/4).