### PR TITLE
Do not print key material

### DIFF
--- a/ohttp/src/rh/hpke.rs
+++ b/ohttp/src/rh/hpke.rs
@@ -120,7 +120,7 @@ impl PrivateKey {
 impl std::fmt::Debug for PrivateKey {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         if let Ok(b) = self.key_data() {
-            write!(f, "PrivateKey {}", hex::encode(b))
+            write!(f, "PrivateKey [REDACTED]")
         } else {
             write!(f, "Opaque PrivateKey")
         }


### PR DESCRIPTION
I've noticed that some devs are accidently printing KeyPair. Private keys then end up getting persisted in logs. 