### PR TITLE
Remove mut ref on `KeyConfig` in `HpkeS::new`

### DIFF
--- a/ohttp/src/nss/hpke.rs
+++ b/ohttp/src/nss/hpke.rs
@@ -116,7 +116,7 @@ pub struct HpkeS {
 impl HpkeS {
     /// Create a new context that uses the KEM mode for sending.
     #[allow(clippy::similar_names)]
-    pub fn new(config: Config, pk_r: &mut PublicKey, info: &[u8]) -> Res<Self> {
+    pub fn new(config: Config, pk_r: &PublicKey, info: &[u8]) -> Res<Self> {
         let (sk_e, pk_e) = generate_key_pair(config.kem)?;
         let context = HpkeContext::new(config)?;
         secstatus_to_res(unsafe {

--- a/ohttp/src/rh/hpke.rs
+++ b/ohttp/src/rh/hpke.rs
@@ -172,7 +172,7 @@ pub struct HpkeS {
 
 impl HpkeS {
     /// Create a new context that uses the KEM mode for sending.
-    pub fn new(config: Config, pk_r: &mut PublicKey, info: &[u8]) -> Res<Self> {
+    pub fn new(config: Config, pk_r: &PublicKey, info: &[u8]) -> Res<Self> {
         let mut csprng = rng();
 
         macro_rules! dispatch_hpkes_new {
@@ -498,8 +498,8 @@ mod test {
     fn make() {
         init();
         let cfg = Config::default();
-        let (sk_r, mut pk_r) = generate_key_pair(cfg.kem()).unwrap();
-        let hpke_s = HpkeS::new(cfg, &mut pk_r, INFO).unwrap();
+        let (sk_r, pk_r) = generate_key_pair(cfg.kem()).unwrap();
+        let hpke_s = HpkeS::new(cfg, &pk_r, INFO).unwrap();
         let _hpke_r = HpkeR::new(cfg, &pk_r, &sk_r, &hpke_s.enc().unwrap(), INFO).unwrap();
     }
 
@@ -513,10 +513,10 @@ mod test {
             ..Config::default()
         };
         assert!(cfg.supported());
-        let (sk_r, mut pk_r) = generate_key_pair(cfg.kem()).unwrap();
+        let (sk_r, pk_r) = generate_key_pair(cfg.kem()).unwrap();
 
         // Send
-        let mut hpke_s = HpkeS::new(cfg, &mut pk_r, INFO).unwrap();
+        let mut hpke_s = HpkeS::new(cfg, &pk_r, INFO).unwrap();
         let enc = hpke_s.enc().unwrap();
         let ct = hpke_s.seal(AAD, PT).unwrap();
 

--- a/ohttp/src/stream.rs
+++ b/ohttp/src/stream.rs
@@ -202,9 +202,9 @@ pub struct ClientRequest<D> {
 
 impl<D> ClientRequest<D> {
     /// Start the processing of a stream.
-    pub fn start(dst: D, config: HpkeConfig, key_id: KeyId, mut pk: PublicKey) -> Res<Self> {
+    pub fn start(dst: D, config: HpkeConfig, key_id: KeyId, pk: &PublicKey) -> Res<Self> {
         let info = build_info(INFO_REQUEST, key_id, config)?;
-        let hpke = HpkeS::new(config, &mut pk, &info)?;
+        let hpke = HpkeS::new(config, pk, &info)?;
 
         let mut header = Vec::from(&info[INFO_REQUEST.len() + 1..]);
         debug_assert_eq!(header.len(), REQUEST_HEADER_LEN);


### PR DESCRIPTION
The `KeyConfig` is not mutated. Having a mutable refrence only complicates the public interface.