### PR TITLE
Make HPKE configuration non-mutable

### DIFF
--- a/ohttp/src/lib.rs
+++ b/ohttp/src/lib.rs
@@ -127,10 +127,10 @@ impl ClientRequest {
 
     /// Encapsulate a request.  This consumes this object.
     /// This produces a response handler and the bytes of an encapsulated request.
-    pub fn encapsulate(mut self, request: &[u8]) -> Res<(Vec<u8>, ClientResponse)> {
+    pub fn encapsulate(self, request: &[u8]) -> Res<(Vec<u8>, ClientResponse)> {
         // Build the info, which contains the message header.
         let info = build_info(INFO_REQUEST, self.key_id, self.config)?;
-        let mut hpke = HpkeS::new(self.config, &mut self.pk, &info)?;
+        let mut hpke = HpkeS::new(self.config, &self.pk, &info)?;
 
         let header = Vec::from(&info[INFO_REQUEST.len() + 1..]);
         debug_assert_eq!(header.len(), REQUEST_HEADER_LEN);
@@ -153,7 +153,7 @@ impl ClientRequest {
 
     #[cfg(feature = "stream")]
     pub fn encapsulate_stream<S>(self, dst: S) -> Res<StreamClient<S>> {
-        StreamClient::start(dst, self.config, self.key_id, self.pk)
+        StreamClient::start(dst, self.config, self.key_id, &self.pk)
     }
 }
 

--- a/ohttp/src/nss/aead.rs
+++ b/ohttp/src/nss/aead.rs
@@ -91,7 +91,7 @@ impl Aead {
         let slot = super::p11::Slot::internal()?;
         let ptr = unsafe {
             sys::PK11_ImportSymKey(
-                *slot,
+                slot.ptr(),
                 Self::mech(algorithm),
                 sys::PK11Origin::PK11_OriginUnwrap,
                 sys::CK_ATTRIBUTE_TYPE::from(sys::CKA_ENCRYPT | sys::CKA_DECRYPT),
@@ -118,7 +118,7 @@ impl Aead {
             PK11_CreateContextBySymKey(
                 Self::mech(algorithm),
                 mode.p11mode(),
-                **key,
+                key.ptr(),
                 &Item::wrap(&nonce_base[..]),
             )
         };
@@ -137,7 +137,7 @@ impl Aead {
         let pt_expected = ct.len().checked_sub(TAG_LEN).ok_or(Error::Truncated)?;
         secstatus_to_res(unsafe {
             PK11_AEADOp(
-                **ctx,
+                ctx.ptr(),
                 CK_GENERATOR_FUNCTION::from(mech),
                 c_int_len(NONCE_LEN - COUNTER_LEN), // Fixed portion of the nonce.
                 nonce.as_mut_ptr(),
@@ -198,7 +198,7 @@ impl Encrypt for Aead {
         let mut tag = vec![0; TAG_LEN];
         secstatus_to_res(unsafe {
             PK11_AEADOp(
-                *self.ctx,
+                self.ctx.ptr(),
                 CK_GENERATOR_FUNCTION::from(CKG_GENERATE_COUNTER_XOR),
                 c_int_len(NONCE_LEN - COUNTER_LEN), // Fixed portion of the nonce.
                 nonce.as_mut_ptr(),

--- a/ohttp/src/nss/err.rs
+++ b/ohttp/src/nss/err.rs
@@ -63,12 +63,12 @@ impl std::fmt::Display for Error {
     }
 }
 
-use std::ffi::CStr;
-
 fn wrap_str_fn<F>(f: F, dflt: &str) -> String
 where
     F: FnOnce() -> *const c_char,
 {
+    use std::ffi::CStr;
+
     unsafe {
         let p = f();
         if p.is_null() {

--- a/ohttp/src/nss/hkdf.rs
+++ b/ohttp/src/nss/hkdf.rs
@@ -53,7 +53,7 @@ impl Hkdf {
         let slot = super::p11::Slot::internal()?;
         let ptr = unsafe {
             sys::PK11_ImportSymKey(
-                *slot,
+                slot.ptr(),
                 CK_MECHANISM_TYPE::from(sys::CKM_HKDF_KEY_GEN),
                 sys::PK11Origin::PK11_OriginUnwrap,
                 sys::CK_ATTRIBUTE_TYPE::from(sys::CKA_SIGN),
@@ -91,7 +91,7 @@ impl Hkdf {
         let mut params_item = ParamItem::new(&mut params);
         let ptr = unsafe {
             sys::PK11_Derive(
-                **ikm,
+                ikm.ptr(),
                 CK_MECHANISM_TYPE::from(CKM_HKDF_DERIVE),
                 params_item.ptr(),
                 CK_MECHANISM_TYPE::from(CKM_HKDF_DERIVE),
@@ -130,7 +130,7 @@ impl Hkdf {
         let mut params_item = ParamItem::new(&mut params);
         let ptr = unsafe {
             sys::PK11_Derive(
-                **prk,
+                prk.ptr(),
                 CK_MECHANISM_TYPE::from(CKM_HKDF_DERIVE),
                 params_item.ptr(),
                 key_mech.mech(),
@@ -153,7 +153,7 @@ impl Hkdf {
         let mut params_item = ParamItem::new(&mut params);
         let ptr = unsafe {
             sys::PK11_Derive(
-                **prk,
+                prk.ptr(),
                 CK_MECHANISM_TYPE::from(CKM_HKDF_DATA),
                 params_item.ptr(),
                 CK_MECHANISM_TYPE::from(CKM_HKDF_DERIVE),

--- a/ohttp/src/nss/p11.rs
+++ b/ohttp/src/nss/p11.rs
@@ -12,8 +12,10 @@ use std::{
     ptr::{self, null_mut},
 };
 
-use super::err::{secstatus_to_res, Error};
-use crate::err::Res;
+use crate::{
+    err::{Error, Res},
+    nss::err::{secstatus_to_res, Error as NssError},
+};
 
 #[allow(
     clippy::pedantic,
@@ -37,7 +39,7 @@ use sys::{
 };
 
 macro_rules! scoped_ptr {
-    ($scoped:ident, $target:ty, $dtor:path) => {
+    ($scoped:ident, $target:ty, $dtor:path, noptr) => {
         pub struct $scoped {
             ptr: *mut $target,
         }
@@ -52,22 +54,17 @@ macro_rules! scoped_ptr {
             }
         }
 
-        impl std::ops::Deref for $scoped {
-            type Target = *mut $target;
-            fn deref(&self) -> &*mut $target {
-                &self.ptr
-            }
-        }
-
-        impl std::ops::DerefMut for $scoped {
-            fn deref_mut(&mut self) -> &mut *mut $target {
-                &mut self.ptr
-            }
-        }
-
         impl Drop for $scoped {
             fn drop(&mut self) {
                 unsafe { $dtor(self.ptr) };
+            }
+        }
+    };
+    ($scoped:ident, $target:ty, $dtor:path) => {
+        scoped_ptr!($scoped, $target, $dtor, noptr);
+        impl $scoped {
+            pub(crate) fn ptr(&self) -> *mut $target {
+                self.ptr
             }
         }
     };
@@ -76,7 +73,11 @@ macro_rules! scoped_ptr {
 scoped_ptr!(PrivateKey, SECKEYPrivateKey, SECKEY_DestroyPrivateKey);
 
 impl PrivateKey {
-    pub fn key_data(&self) -> Res<Vec<u8>> {
+    fn key_data(&self) -> Res<Vec<u8>> {
+        if !cfg!(feature = "unsafe-print-secrets") {
+            return Err(Error::from(NssError::internal()));
+        }
+
         let mut key_item = SECItem {
             type_: SECItemType::siBuffer,
             data: null_mut(),
@@ -85,7 +86,7 @@ impl PrivateKey {
         secstatus_to_res(unsafe {
             PK11_ReadRawAttribute(
                 PK11ObjectType::PK11_TypePrivKey,
-                (**self).cast(),
+                self.ptr().cast(),
                 CK_ATTRIBUTE_TYPE::from(CKA_VALUE),
                 &raw mut key_item,
             )
@@ -115,12 +116,11 @@ impl Clone for PrivateKey {
 
 impl std::fmt::Debug for PrivateKey {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        if cfg!(feature = "unsafe-print-secrets") {
-            if let Ok(b) = self.key_data() {
-                return write!(f, "PrivateKey {}", hex::encode(b));
-            }
+        if let Ok(b) = self.key_data() {
+            write!(f, "PrivateKey {}", hex::encode(b))
+        } else {
+            write!(f, "Opaque PrivateKey")
         }
-        write!(f, "Opaque PrivateKey")
     }
 }
 
@@ -133,7 +133,7 @@ impl PublicKey {
         let mut len: c_uint = 0;
         secstatus_to_res(unsafe {
             sys::PK11_HPKE_Serialize(
-                **self,
+                self.ptr(),
                 buf.as_mut_ptr(),
                 &raw mut len,
                 c_uint::try_from(buf.len()).unwrap(),
@@ -187,7 +187,7 @@ impl SymKey {
         let key_item = unsafe { PK11_GetKeyData(self.ptr) };
         // This is accessing a value attached to the key, so we can treat this as a borrow.
         match unsafe { key_item.as_mut() } {
-            None => Err(Error::last()),
+            None => Err(NssError::last()),
             Some(key) => Ok(unsafe { std::slice::from_raw_parts(key.data, key.len as usize) }),
         }
     }
@@ -251,7 +251,7 @@ impl<'a, T: Sized + 'a> ParamItem<'a, T> {
 unsafe fn destroy_secitem(item: *mut SECItem) {
     SECITEM_FreeItem(item, PRBool::from(true));
 }
-scoped_ptr!(Item, SECItem, destroy_secitem);
+scoped_ptr!(Item, SECItem, destroy_secitem, noptr);
 
 impl Item {
     /// Create a wrapper for a slice of this object.

--- a/ohttp/src/rh/hpke.rs
+++ b/ohttp/src/rh/hpke.rs
@@ -172,7 +172,7 @@ pub struct HpkeS {
 
 impl HpkeS {
     /// Create a new context that uses the KEM mode for sending.
-    pub fn new(config: Config, pk_r: &mut PublicKey, info: &[u8]) -> Res<Self> {
+    pub fn new(config: Config, pk_r: &PublicKey, info: &[u8]) -> Res<Self> {
         let mut csprng = rng();
 
         macro_rules! dispatch_hpkes_new {
@@ -498,8 +498,8 @@ mod test {
     fn make() {
         init();
         let cfg = Config::default();
-        let (sk_r, mut pk_r) = generate_key_pair(cfg.kem()).unwrap();
-        let hpke_s = HpkeS::new(cfg, &mut pk_r, INFO).unwrap();
+        let (sk_r, pk_r) = generate_key_pair(cfg.kem()).unwrap();
+        let hpke_s = HpkeS::new(cfg, &pk_r, INFO).unwrap();
         let _hpke_r = HpkeR::new(cfg, &pk_r, &sk_r, &hpke_s.enc().unwrap(), INFO).unwrap();
     }
 
@@ -513,10 +513,10 @@ mod test {
             ..Config::default()
         };
         assert!(cfg.supported());
-        let (sk_r, mut pk_r) = generate_key_pair(cfg.kem()).unwrap();
+        let (sk_r, pk_r) = generate_key_pair(cfg.kem()).unwrap();
 
         // Send
-        let mut hpke_s = HpkeS::new(cfg, &mut pk_r, INFO).unwrap();
+        let mut hpke_s = HpkeS::new(cfg, &pk_r, INFO).unwrap();
         let enc = hpke_s.enc().unwrap();
         let ct = hpke_s.seal(AAD, PT).unwrap();
 

--- a/ohttp/src/stream.rs
+++ b/ohttp/src/stream.rs
@@ -202,9 +202,9 @@ pub struct ClientRequest<D> {
 
 impl<D> ClientRequest<D> {
     /// Start the processing of a stream.
-    pub fn start(dst: D, config: HpkeConfig, key_id: KeyId, mut pk: PublicKey) -> Res<Self> {
+    pub fn start(dst: D, config: HpkeConfig, key_id: KeyId, pk: &PublicKey) -> Res<Self> {
         let info = build_info(INFO_REQUEST, key_id, config)?;
-        let hpke = HpkeS::new(config, &mut pk, &info)?;
+        let hpke = HpkeS::new(config, pk, &info)?;
 
         let mut header = Vec::from(&info[INFO_REQUEST.len() + 1..]);
         debug_assert_eq!(header.len(), REQUEST_HEADER_LEN);


### PR DESCRIPTION
This turns out to be easy enough for NSS, but I had to do away with the use of Deref for all the wrapped types.  The net effect is much nicer as as result.

Closes #83.